### PR TITLE
Attempt to solve a NPE, possibly due to concurrent usage of ManifestV…

### DIFF
--- a/src/main/java/org/jboss/set/components/ManifestVerifier.java
+++ b/src/main/java/org/jboss/set/components/ManifestVerifier.java
@@ -13,7 +13,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -118,13 +117,11 @@ public class ManifestVerifier {
     }
 
     static class BuildRecorder {
-        Map<PncComponent, Map<PncBuild.Id, Collection<ArtifactCoordinate>>> buildsByComponent = new HashMap<>();
+        Map<PncComponent, Map<PncBuild.Id, Collection<ArtifactCoordinate>>> buildsByComponent = new ConcurrentHashMap<>();
         void record(PncBuild.Id buildId, PncComponent component, ArtifactCoordinate artifactCoordinate) {
-            buildsByComponent.putIfAbsent(component, new ConcurrentHashMap<>());
-
-            buildsByComponent.get(component).putIfAbsent(buildId, new ConcurrentLinkedQueue<>());
-
-            buildsByComponent.get(component).get(buildId).add(artifactCoordinate);
+            Map<PncBuild.Id, Collection<ArtifactCoordinate>> buildToArtifacts = buildsByComponent.computeIfAbsent(component, k -> new ConcurrentHashMap<>());
+            Collection<ArtifactCoordinate> artifacts = buildToArtifacts.computeIfAbsent(buildId, k -> new ConcurrentLinkedQueue<>());
+            artifacts.add(artifactCoordinate);
         }
 
         Collection<PncComponent> recordedComponents() {


### PR DESCRIPTION
…erifier

@spyrkob I'm still seeing occasional NPEs being thrown by the validator.

https://brontes02-host.lab.eng.brq2.redhat.com/job/eap-8.0/job/pipeline-jobs/job/prospero-eap/345/console

```
Caused by: java.lang.NullPointerException
	at org.jboss.set.components.ManifestVerifier$BuildRecorder.record(ManifestVerifier.java:125)
	at org.jboss.set.components.ManifestVerifier.lambda$verifyComponents$0(ManifestVerifier.java:69)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.TreeMap$KeySpliterator.forEachRemaining(TreeMap.java:2739)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

I didn't manage to reproduce locally (I tried a test case concurrently calling `buildRecorder.record(pncBuild, pncComponent, artifact);`, but no luck), so this is a blind fix.

By the stack trace, it looks that the line:

```
buildsByComponent.get(component).putIfAbsent(buildId, new ConcurrentLinkedQueue<>());
```

has to be returning null from `buildsByComponent.get(component)` (unless some more stack lines were swallowed).